### PR TITLE
Module require() varargs

### DIFF
--- a/js/lua-parser.js
+++ b/js/lua-parser.js
@@ -141,7 +141,7 @@ case 1:
       "};\n" +
 	  "LuaBootStrap(G);\n"+ // added 2012-03 by ghoulsblade for love-webplayer
       "{\n" +
-      "  varargs = arguments;\n" +
+      "  varargs = arguments;\n" + // added 2013-02 by campadrenalin for love-webplayer
       $$[$0-2].simple_form + "\n" +
       "}\n";
   

--- a/js/lua-parser.js
+++ b/js/lua-parser.js
@@ -141,6 +141,7 @@ case 1:
       "};\n" +
 	  "LuaBootStrap(G);\n"+ // added 2012-03 by ghoulsblade for love-webplayer
       "{\n" +
+      "  varargs = arguments;\n" +
       $$[$0-2].simple_form + "\n" +
       "}\n";
   

--- a/js/main.js
+++ b/js/main.js
@@ -167,8 +167,8 @@ function LuaBootStrap (G) {
 		
 		var initpath = path+"/init.lua"; // require("shaders") -> shaders/init.lua 
 		if (LoveFS_exists(initpath)) 
-				return RunLuaFromPath(initpath);
-		else	return RunLuaFromPath(path + ".lua"); // require("bla") -> bla.lua
+				return RunLuaFromPath(initpath, false, path);
+		else	return RunLuaFromPath(path + ".lua", false, path); // require("bla") -> bla.lua
 		
 		//~ NOTE: replaces parser lib lua_require(G, path);
 	};
@@ -251,7 +251,7 @@ function LoveRequireSocketHTTP () {
 }
 
 /// synchronous ajax to get file, so code executed before function returns
-function RunLuaFromPath (path, safe) {
+function RunLuaFromPath (path, safe, modulename) {
 	if (gLoveExecutionHalted) return;
 	if (!lua_parser) {
 		throw new Error("Lua parser not available, perhaps you're not using the lua+parser.js version of the library?");
@@ -275,7 +275,7 @@ function RunLuaFromPath (path, safe) {
 		MyProfileStart("RunLuaFromPath:parse:"+path);
 		var myfun = lua_load(luacode,temp_function_name); // parse code
 		MyProfileStart("RunLuaFromPath:run:"+path);
-		var res = myfun(); // run code, returns _G
+		var res = myfun(modulename); // run code, returns _G
 		MyProfileEnd();
 		return res;
 	} catch (e) {


### PR DESCRIPTION
Some modules use the `(...)` construct to retrieve the module name relative to the importer. It's possible that this should be provided with the actual arguments passed to require, in which case, this will need follow-up work. But this preserves the module name as originally required, and passes it on down to the module.
