### PR TITLE
Add vim swp files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /ludumdare201204/
 /ludumdare201208/
 /devmania2011/
+
+*.swp


### PR DESCRIPTION
I use vim heavily, and when git thinks that the .swp temp files are real, "I want to commit this" content, it's extremely irritating, forcing me to carefully stage around the temp files. This change should have no effect on non-vim-users, but makes a big difference for vimmers like me.
